### PR TITLE
11 build emitters

### DIFF
--- a/.github/workflows/python-smoke-test.yml
+++ b/.github/workflows/python-smoke-test.yml
@@ -44,4 +44,4 @@ jobs:
 
     - name: "Run tox for ${{ matrix.python-version }}"
       run: |
-        python echo_sound_sim.py tests/test_data/test_mesh.stl -sr=1 -vel=50
+        python echo_sound_sim.py tests/test_data/test_mesh.stl -sr=1 -vel=50 --no-wait

--- a/echo_sound_sim.py
+++ b/echo_sound_sim.py
@@ -22,8 +22,9 @@ if __name__ == '__main__':
     wait_secs = 1 / args.sample_rate
 
     # Run the sampling
+    emitter = args.emitter_type
     for x, y in parallel_track_sampling_generator(min_x, max_x, min_y, max_y, right, up):
         new_vector, exec_time = process_position(mesh, x, y, args.errors)
         if new_vector is not None:
-            print(new_vector)
+            emitter.emit_vector(new_vector)
         time.sleep(max(wait_secs - exec_time, 0))

--- a/echo_sound_sim.py
+++ b/echo_sound_sim.py
@@ -24,7 +24,9 @@ if __name__ == '__main__':
     # Run the sampling
     emitter = args.emitter_type
     for x, y in parallel_track_sampling_generator(min_x, max_x, min_y, max_y, right, up):
+        t1 = time.time()
         new_vector, exec_time = process_position(mesh, x, y, args.errors)
         if new_vector is not None:
             emitter.emit_vector(new_vector)
-        time.sleep(max(wait_secs - exec_time, 0))
+            t2 = time.time()
+            time.sleep(max(wait_secs - (t2 - t1), 0))

--- a/echo_sound_sim.py
+++ b/echo_sound_sim.py
@@ -12,6 +12,7 @@ if __name__ == '__main__':
 
     # Import data file
     mesh = load(args.data_file)
+    wait = not args.no_wait
 
     # get movement parameters
     min_x, min_y, _ = mesh.bounds[0]
@@ -29,4 +30,5 @@ if __name__ == '__main__':
         if new_vector is not None:
             emitter.emit_vector(new_vector)
             t2 = time.time()
-            time.sleep(max(wait_secs - (t2 - t1), 0))
+            if wait:
+                time.sleep(max(wait_secs - (t2 - t1), 0))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 trimesh==4.0.8
 numpy==1.26.3
+requests==2.31.0
 mkdocs==1.5.3
 mkdocstrings-python==1.8.0
 mkdocs-material==9.5.3

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -13,7 +13,12 @@ class TestArgumentParsing(unittest.TestCase):
         args = ["test.stl"]
         arg_space = parse_args(args)
 
-        self.assertSetEqual(set(arg_space.__dict__.keys()), {"errors", "sample_rate", "data_file", "velocity"})
+        self.assertSetEqual(set(arg_space.__dict__.keys()), {"errors",
+                                                             "sample_rate",
+                                                             "data_file",
+                                                             "velocity",
+                                                             "emitter_type",
+                                                             "no_wait"})
         self.assertEqual(arg_space.errors, [])
         self.assertEqual(arg_space.sample_rate, 1)
         self.assertEqual(arg_space.data_file, "test.stl")

--- a/utils/cli_parsing.py
+++ b/utils/cli_parsing.py
@@ -66,4 +66,8 @@ def parse_args(args):
                         type=float,
                         default=1,
                         help="The velocity of the research vessel in m/s. Defaults to 1 m/s (3.6 km/hr)")
+    parser.add_argument("--no-wait",
+                        action="store_true",
+                        help="Flag to disable the waiting part off the simulation. If given, the sampling rate "
+                             "will remain the same, but the wait time between samples will be disabled.")
     return parser.parse_args(args)

--- a/utils/cli_parsing.py
+++ b/utils/cli_parsing.py
@@ -1,6 +1,6 @@
 import argparse
 
-from utils.emitters import StdOutVectorEmitter
+from utils.emitters import StdOutVectorEmitter, CsvVectorEmitter, TsvVectorEmitter, EndpointVectorEmitter
 from utils.error_pipeline import Noise
 
 
@@ -25,13 +25,14 @@ class ParseVectorEmitter(argparse.Action):
         super().__init__(option_strings, dest, **kwargs)
 
     def __call__(self, parser, namespace, values, option_string=None):
-        match values:
-            case "file":
-                item = StdOutVectorEmitter()
+        emitter, location = values.split("@")
+        match emitter:
+            case "csv":
+                item = CsvVectorEmitter(location)
+            case "tsv":
+                item = TsvVectorEmitter(location)
             case "endpoint":
-                item = StdOutVectorEmitter()
-            case "stdout":
-                item = StdOutVectorEmitter()
+                item = EndpointVectorEmitter(location)
             case _:
                 item = StdOutVectorEmitter()
 
@@ -45,8 +46,8 @@ def parse_args(args):
     parser.add_argument("-em",
                         "--emitter_type",
                         action=ParseVectorEmitter,
-                        help="Where you want to emit the result vectors.",
-                        choices=["stdout", "file", "endpoint"],
+                        help="Where you want to emit the result vectors, if not to stdout.",
+                        choices=["csv@<filename>", "tsv@<filename>", "endpoint@<url>"],
                         default=StdOutVectorEmitter())
     parser.add_argument("-sr",
                         "--sample_rate",

--- a/utils/cli_parsing.py
+++ b/utils/cli_parsing.py
@@ -1,5 +1,6 @@
 import argparse
 
+from utils.emitters import StdOutVectorEmitter
 from utils.error_pipeline import Noise
 
 
@@ -17,10 +18,36 @@ class ParseErrorPipeline(argparse.Action):
         setattr(namespace, self.dest, items)
 
 
+class ParseVectorEmitter(argparse.Action):
+    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+        if nargs is not None:
+            raise ValueError("nargs not allowed")
+        super().__init__(option_strings, dest, **kwargs)
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        match values:
+            case "file":
+                item = StdOutVectorEmitter()
+            case "endpoint":
+                item = StdOutVectorEmitter()
+            case "stdout":
+                item = StdOutVectorEmitter()
+            case _:
+                item = StdOutVectorEmitter()
+
+        setattr(namespace, self.dest, item)
+
+
 def parse_args(args):
     parser = argparse.ArgumentParser()
     parser.add_argument("data_file",
                         help="An 3D data file to represent the surface to sample")
+    parser.add_argument("-em",
+                        "--emitter_type",
+                        action=ParseVectorEmitter,
+                        help="Where you want to emit the result vectors.",
+                        choices=["stdout", "file", "endpoint"],
+                        default=StdOutVectorEmitter())
     parser.add_argument("-sr",
                         "--sample_rate",
                         help="The rate (in Hertz) at which to sample the surface. Defaults to 1hz.",

--- a/utils/cli_parsing.py
+++ b/utils/cli_parsing.py
@@ -46,8 +46,8 @@ def parse_args(args):
     parser.add_argument("-em",
                         "--emitter_type",
                         action=ParseVectorEmitter,
-                        help="Where you want to emit the result vectors, if not to stdout.",
-                        choices=["csv@<filename>", "tsv@<filename>", "endpoint@<url>"],
+                        help="Where you want to emit the result vectors, if not to stdout.\n"
+                             "Your choices are: csv@<filename>, tsv@<filename>, endpoint@<url>",
                         default=StdOutVectorEmitter())
     parser.add_argument("-sr",
                         "--sample_rate",

--- a/utils/emitters.py
+++ b/utils/emitters.py
@@ -1,0 +1,13 @@
+import abc
+
+
+class VectorEmitter:
+    @abc.abstractmethod
+    def emit_vector(self, vector):
+        raise NotImplementedError("You must override emit_vector()")
+
+
+class StdOutVectorEmitter(VectorEmitter):
+    def emit_vector(self, vector):
+        print(vector)
+

--- a/utils/emitters.py
+++ b/utils/emitters.py
@@ -1,4 +1,6 @@
 import abc
+import json
+
 import requests
 
 
@@ -20,7 +22,7 @@ class CsvVectorEmitter(VectorEmitter):
 
     def emit_vector(self, vector):
         out_str = f"{vector[0]},{vector[1]},{vector[2]}\n"
-        with open(self.filename) as f:
+        with open(self.filename, "a+") as f:
             f.write(out_str)
 
 
@@ -31,7 +33,7 @@ class TsvVectorEmitter(VectorEmitter):
 
     def emit_vector(self, vector):
         out_str = f"{vector[0]}\t{vector[1]}\t{vector[2]}\n"
-        with open(self.filename) as f:
+        with open(self.filename, "a+") as f:
             f.write(out_str)
 
 
@@ -41,11 +43,17 @@ class EndpointVectorEmitter(VectorEmitter):
         self.endpoint = endpoint
 
     def emit_vector(self, vector):
-        body = {
+        payload = {
             "x": vector[0],
             "y": vector[1],
             "z": vector[2]
         }
-        requests.put(self.endpoint, data=body)
-        print(vector)
+        response = requests.put(
+            url=self.endpoint,
+            data=json.dumps(payload),
+            headers={
+                "Content-Type": "application/json"
+            }
+        )
+        print(f"Response {response.status_code} from {self.endpoint}\n{json.dumps(response.text, indent=4)}")
 

--- a/utils/emitters.py
+++ b/utils/emitters.py
@@ -1,4 +1,5 @@
 import abc
+import requests
 
 
 class VectorEmitter:
@@ -9,5 +10,42 @@ class VectorEmitter:
 
 class StdOutVectorEmitter(VectorEmitter):
     def emit_vector(self, vector):
+        print(vector)
+
+
+class CsvVectorEmitter(VectorEmitter):
+    def __init__(self, filename):
+        super().__init__()
+        self.filename = filename
+
+    def emit_vector(self, vector):
+        out_str = f"{vector[0]},{vector[1]},{vector[2]}\n"
+        with open(self.filename) as f:
+            f.write(out_str)
+
+
+class TsvVectorEmitter(VectorEmitter):
+    def __init__(self, filename):
+        super().__init__()
+        self.filename = filename
+
+    def emit_vector(self, vector):
+        out_str = f"{vector[0]}\t{vector[1]}\t{vector[2]}\n"
+        with open(self.filename) as f:
+            f.write(out_str)
+
+
+class EndpointVectorEmitter(VectorEmitter):
+    def __init__(self, endpoint):
+        super().__init__()
+        self.endpoint = endpoint
+
+    def emit_vector(self, vector):
+        body = {
+            "x": vector[0],
+            "y": vector[1],
+            "z": vector[2]
+        }
+        requests.put(self.endpoint, data=body)
         print(vector)
 

--- a/utils/emitters.py
+++ b/utils/emitters.py
@@ -56,4 +56,3 @@ class EndpointVectorEmitter(VectorEmitter):
             }
         )
         print(f"Response {response.status_code} from {self.endpoint}\n{json.dumps(response.text, indent=4)}")
-


### PR DESCRIPTION
Added four emitters that can be specified at runtime:
- Terminal
- CSV
- TSV
- Endpoint
Added a `--no-wait` flag to disable the simulator's wait time while maintaining the sampling reading behaviour

Tested against the visualizer